### PR TITLE
allow to specify the ROM version explicitly

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -67,7 +67,8 @@ void usage(void)
 			VERSION_MAJOR, VERSION_MINOR, git_sha);
 	printf("ROM Version %d\n", plat_config_data->m_u32RomVer);
 	printf(
-	"usage: kobs-ng [COMMAND] [ARGS]\n"
+	"usage: kobs-ng [-r <ROM version>] [COMMAND] [ARGS]\n"
+	"Where <ROM version> is one of: mx23 mx28 mx50 mx53to1 mx53to2 mx6q mx6sx mx6sx_to_1_2 mx7d mx6ul\n"
 	"Where [COMMAND] is one of:\n"
 	"\n"
 	"  dump [-v] [KOBS] ........................ Verify/dump boot structures\n"
@@ -830,16 +831,50 @@ int main(int argc, char **argv)
 {
 	int ret;
 
-	ret = discover_boot_rom_version();
-	if (ret != 0) {
-		printf("We can not find the right ROM version!\n");
-		exit(1);
-	}
-
 	if (argc < 2)
 		usage();
 	argc--;
 	argv++;
+
+	if (strcmp(argv[0], "-r") == 0) {
+		if (argc < 2)
+			usage();
+		argc--;
+		argv++;
+		if (strcmp(argv[0], "mx23") == 0) {
+			plat_config_data = &mx23_boot_config;
+		} else if (strcmp(argv[0], "mx28") == 0) {
+			plat_config_data = &mx28_boot_config;
+		} else if (strcmp(argv[0], "mx50") == 0) {
+			plat_config_data = &mx50_boot_config;
+		} else if (strcmp(argv[0], "mx53to1") == 0) {
+			plat_config_data = &mx53to1_boot_config;
+		} else if (strcmp(argv[0], "mx53to2") == 0) {
+			plat_config_data = &mx53to1_boot_config;
+		} else if (strcmp(argv[0], "mx6q") == 0) {
+			plat_config_data = &mx6q_boot_config;
+		} else if (strcmp(argv[0], "mx6sx") == 0) {
+			plat_config_data = &mx6sx_boot_config;
+		} else if (strcmp(argv[0], "mx6sx_to_1_2") == 0) {
+			plat_config_data = &mx6sx_to_1_2_boot_config;
+		} else if (strcmp(argv[0], "mx7d") == 0) {
+			plat_config_data = &mx7d_boot_config;
+		} else if (strcmp(argv[0], "mx6ul") == 0) {
+			plat_config_data = &mx6ul_boot_config;
+		} else
+			usage();
+		argc--;
+		argv++;
+	}
+	else {
+		ret = discover_boot_rom_version();
+		if (ret != 0) {
+			printf("We can not find the right ROM version!\n");
+			exit(1);
+		}
+	}
+	if (0 == argc )
+		usage();
 
 	if (strcmp(argv[0], "dump") == 0)
 		return dump_main(argc, argv);

--- a/src/plat_boot_config.c
+++ b/src/plat_boot_config.c
@@ -28,7 +28,7 @@
 /* System version */
 platform_config *plat_config_data;
 
-static platform_config mx23_boot_config = {
+platform_config mx23_boot_config = {
 	.m_u32RomVer = ROM_Version_0,
 	.m_u32EnDISBBM = 0,
 	.m_u32EnSoftEcc = 0,
@@ -42,7 +42,7 @@ static platform_config mx23_boot_config = {
 	.rom_mtd_commit_structures = v0_rom_mtd_commit_structures,
 };
 
-static platform_config mx28_boot_config = {
+platform_config mx28_boot_config = {
 	.m_u32RomVer = ROM_Version_1,
 	.m_u32EnDISBBM = 0,
 	.m_u32EnSoftEcc = 1,
@@ -56,7 +56,7 @@ static platform_config mx28_boot_config = {
 	.rom_mtd_commit_structures = v1_rom_mtd_commit_structures,
 };
 
-static platform_config mx53to1_boot_config = {
+platform_config mx53to1_boot_config = {
 	.m_u32RomVer = ROM_Version_2,
 	.m_u32EnDISBBM = 0,
 	.m_u32EnSoftEcc = 0,
@@ -70,7 +70,7 @@ static platform_config mx53to1_boot_config = {
 	.rom_mtd_commit_structures = v2_rom_mtd_commit_structures,
 };
 
-static platform_config mx53to2_boot_config = {
+platform_config mx53to2_boot_config = {
 	.m_u32RomVer = ROM_Version_2,
 	.m_u32EnDISBBM = 1,
 	.m_u32EnSoftEcc = 0,
@@ -84,7 +84,7 @@ static platform_config mx53to2_boot_config = {
 	.rom_mtd_commit_structures = v2_rom_mtd_commit_structures,
 };
 
-static platform_config mx50_boot_config = {
+platform_config mx50_boot_config = {
 	.m_u32RomVer = ROM_Version_3,
 	.m_u32EnDISBBM = 0,
 	.m_u32EnSoftEcc = 1,
@@ -98,7 +98,7 @@ static platform_config mx50_boot_config = {
 	.rom_mtd_commit_structures = v4_rom_mtd_commit_structures,
 };
 
-static platform_config mx6q_boot_config = {
+platform_config mx6q_boot_config = {
 	.m_u32RomVer = ROM_Version_3,
 	.m_u32EnDISBBM = 0,
 	.m_u32EnBootStreamVerify = 0,
@@ -111,7 +111,7 @@ static platform_config mx6q_boot_config = {
 	.rom_mtd_commit_structures = v4_rom_mtd_commit_structures,
 };
 
-static platform_config mx6sx_boot_config = {
+platform_config mx6sx_boot_config = {
 	.m_u32RomVer = ROM_Version_4,
 	.m_u32EnDISBBM = 0,
 	.m_u32EnBootStreamVerify = 0,
@@ -124,7 +124,7 @@ static platform_config mx6sx_boot_config = {
 	.rom_mtd_commit_structures = v4_rom_mtd_commit_structures,
 };
 
-static platform_config mx6sx_to_1_2_boot_config = {
+platform_config mx6sx_to_1_2_boot_config = {
 	.m_u32RomVer = ROM_Version_5,
 	.m_u32EnDISBBM = 0,
 	.m_u32EnBootStreamVerify = 0,
@@ -137,7 +137,7 @@ static platform_config mx6sx_to_1_2_boot_config = {
 	.rom_mtd_commit_structures = v5_rom_mtd_commit_structures,
 };
 
-static platform_config mx7d_boot_config = {
+platform_config mx7d_boot_config = {
 	.m_u32RomVer = ROM_Version_5,
 	.m_u32EnDISBBM = 0,
 	.m_u32EnBootStreamVerify = 0,
@@ -150,7 +150,7 @@ static platform_config mx7d_boot_config = {
 	.rom_mtd_commit_structures = v5_rom_mtd_commit_structures,
 };
 
-static platform_config mx6ul_boot_config = {
+platform_config mx6ul_boot_config = {
 	.m_u32RomVer = ROM_Version_5,
 	.m_u32EnDISBBM = 0,
 	.m_u32EnBootStreamVerify = 0,

--- a/src/plat_boot_config.h
+++ b/src/plat_boot_config.h
@@ -62,6 +62,16 @@ typedef struct _platform_config_t {
 } platform_config;
 
 extern platform_config *plat_config_data;
+extern platform_config mx23_boot_config;
+extern platform_config mx28_boot_config;
+extern platform_config mx50_boot_config;
+extern platform_config mx53to1_boot_config;
+extern platform_config mx53to2_boot_config;
+extern platform_config mx6q_boot_config;
+extern platform_config mx6sx_boot_config;
+extern platform_config mx6sx_to_1_2_boot_config;
+extern platform_config mx7d_boot_config;
+extern platform_config mx6ul_boot_config;
 
 extern int discover_boot_rom_version(void);
 


### PR DESCRIPTION
Based on: https://github.com/benavrhm/kobs-ng-patches

 This patch to kobs-ng allows you to specify the ROM version explicitly using a
 command line parameter. For example "kobs-ng -r mx28 init ...".

 Using this patch allows you to avoid the broken heuristic on /proc/cpuinfo
 in src/plat_boot_config.c:discover_boot_rom_version() that results in the
 lame message:

 "Couldn't find Boot ROM version
 We can not find the right ROM version!"

 There is in fact no connection between the content of /proc/cpuinfo and the
 SoC ROM version, except in some particular versions of the kernel that were
 distributed by Freescale some time ago.

 This patch was made for version kobs-ng-3.0.35-4.0.0 that is used in
 buildroot-2013.11.

 I place this patch in the public domain in the hope that it will be useful,
 but there is no warranty. You use this patch at your own risk.
 Jonathan Ben-Avraham <yba@tkos.co.il>