### PR TITLE
imx-kobs: Fix compiler error with Linux kernel headers version >= 4.4

### DIFF
--- a/src/BootControlBlocks.h
+++ b/src/BootControlBlocks.h
@@ -54,6 +54,8 @@
 //! This structure holds the timing for the NAND.  This data is used by
 //! rom_nand_hal_GpmiSetNandTiming to setup the GPMI hardware registers.
 
+#include <stdint.h>
+
 typedef struct _NAND_Timing {
 	uint8_t m_u8DataSetup;
 	uint8_t m_u8DataHold;


### PR DESCRIPTION
This patch fixes a build error with kernel includes (>= 4.4) <stdint.h>
must be explicitly included to get uintX_t types.

The patch copied from
https://github.com/Freescale/meta-freescale/blob/master/recipes-bsp/imx-kobs/imx-kobs/fix-compile.patch

Signed-off-by: Gary Thomas <gary@mlbassoc.com>
Signed-off-by: Otavio Salvador <otavio@ossystems.com.br>
Signed-off-by: Han Xu <han.xu@nxp.com>