### PR TITLE
imx-kobs: support i.MX8 platforms

### DIFF
--- a/src/mtd.c
+++ b/src/mtd.c
@@ -898,6 +898,7 @@ struct mtd_data *mtd_open(const struct mtd_config *cfg, int flags)
 
 		/* verify it's a supported geometry */
 		if (plat_config_data->m_u32Arm_type != MX7 &&
+			plat_config_data->m_u32Arm_type != MX8 &&
 			plat_config_data->m_u32Arm_type != MX6Q &&
 			plat_config_data->m_u32Arm_type != MX6DL &&
 			plat_config_data->m_u32Arm_type != MX6 &&

--- a/src/plat_boot_config.c
+++ b/src/plat_boot_config.c
@@ -163,6 +163,19 @@ static platform_config mx6ul_boot_config = {
 	.rom_mtd_commit_structures = v6_rom_mtd_commit_structures,
 };
 
+static platform_config mx8_boot_config = {
+	.m_u32RomVer = ROM_Version_5,
+	.m_u32EnDISBBM = 0,
+	.m_u32EnBootStreamVerify = 0,
+	.m_u32UseNfcGeo = 0,
+	.m_u32UseMultiBootArea = 0,
+	.m_u32UseSinglePageStride = 0,
+	.m_u32DBBT_FingerPrint = DBBT_FINGERPRINT2,
+	.m_u32MaxEccStrength = 62,
+	.rom_mtd_init = v4_rom_mtd_init,
+	.rom_mtd_commit_structures = v5_rom_mtd_commit_structures,
+};
+
 int discover_boot_rom_version(void)
 {
 	FILE         *cpuinfo;
@@ -174,8 +187,25 @@ int discover_boot_rom_version(void)
 	static char  *plat_imx6sx = "i.MX6SX";
 	static char  *plat_imx6ul = "i.MX6UL";
 	static char  *plat_imx6ull = "i.MX6ULL";
+	static char  *plat_imx8 = "i.MX8";
 	char *rev;
 	int system_rev, hw_system_rev = 0;
+
+
+	/* check if it is i.MX8 platform */
+	soc_id = fopen("/sys/devices/soc0/soc_id", "r");
+	if (soc_id) {
+		fgets(line_buffer, sizeof(line_buffer), soc_id);
+		fclose(soc_id);
+
+		if (!strncmp(line_buffer, plat_imx8, strlen(plat_imx8))) {
+			plat_config_data = &mx8_boot_config;
+			plat_config_data->m_u32Arm_type = MX8;
+			return 0;
+		}
+
+		memset(line_buffer, 0, sizeof(line_buffer));
+	}
 
 	cpuinfo = fopen("/proc/cpuinfo", "r");
 	if (!cpuinfo) {

--- a/src/plat_boot_config.h
+++ b/src/plat_boot_config.h
@@ -45,6 +45,7 @@
 #define MX6DL	0x61
 
 #define MX7	0x7
+#define MX8	0x8
 
 typedef struct _platform_config_t {
 	uint32_t m_u32RomVer;


### PR DESCRIPTION
i.MX8 platforms use the same FCB settings with i.MX7D. Add new platform
entry to support NAND boot on i.MX8 platforms.

Signed-off-by: Han Xu <han.xu@nxp.com>