### PR TITLE
imx-kobs: support i.MX8MM EVK NAND

### DIFF
--- a/src/plat_boot_config.c
+++ b/src/plat_boot_config.c
@@ -202,6 +202,7 @@ int discover_boot_rom_version(void)
 	static char  *plat_imx6ull = "i.MX6ULL";
 	static char  *plat_imx8q = "i.MX8Q"; /* i.MX8QM or i.MX8QXP */
 	static char  *plat_imx8mq = "i.MX8MQ"; /* i.MX8MQ(mscale) */
+	static char  *plat_imx8mm = "i.MX8MM";
 	char *rev;
 	int system_rev, hw_system_rev = 0;
 
@@ -219,7 +220,8 @@ int discover_boot_rom_version(void)
 			plat_config_data->m_u32Arm_type = MX8Q;
 			return 0;
 
-		} else if (!strncmp(line_buffer, plat_imx8mq, strlen(plat_imx8mq))) {
+		} else if (!strncmp(line_buffer, plat_imx8mq, strlen(plat_imx8mq))
+			   || !strncmp(line_buffer, plat_imx8mm, strlen(plat_imx8mm))) {
 
 			plat_config_data = &mx8mq_boot_config;
 			plat_config_data->m_u32Arm_type = MX8MQ;


### PR DESCRIPTION
i.MX8MM share the same platform config as i.MX8MQ

Signed-off-by: Han Xu <han.xu@nxp.com>