### PR TITLE
i.MX8Q: change the secondary boot stream offset

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -107,6 +107,7 @@ void usage(void)
 	"    --boot_stream_minor_version=<value> .. NCB field (default 0)\n"
 	"    --boot_stream_sub_version=<value> .... NCB field (default 0)\n"
 	"    --ncb_version=<value> ................ NCB field (default 3)\n"
+	"    --secondary_boot_stream_off_in_MB=<value> (default 64MB)\n"
 	"\n"
 	"   [KEY] key management related options\n"
 	"        -d ............................... Use device key (OTP) (not yet supported)\n"

--- a/src/mtd.h
+++ b/src/mtd.h
@@ -88,6 +88,8 @@ struct mtd_config {
 	int stride_size_in_bytes;
 	int search_area_size_in_bytes;
 	int search_area_size_in_pages;
+	/* for i.MX8Q secondary boot container*/
+	int secondary_boot_stream_off_in_MB;
 };
 
 extern const struct mtd_config default_mtd_config;
@@ -227,6 +229,7 @@ enum {
 	ROM_Version_4	    =  4, /* e.g., i.MX6sx */
 	ROM_Version_5	    =  5, /* e.g., i.MX6sx TO1.2*/
 	ROM_Version_6	    =  6, /* e.g., i.MX8MQ*/
+	ROM_Version_7	    =  7, /* e.g., i.MX8Q*/
 };
 
 static inline int mtd_pages_per_block(struct mtd_data *md)

--- a/src/plat_boot_config.c
+++ b/src/plat_boot_config.c
@@ -163,19 +163,6 @@ static platform_config mx6ul_boot_config = {
 	.rom_mtd_commit_structures = v6_rom_mtd_commit_structures,
 };
 
-static platform_config mx8q_boot_config = {
-	.m_u32RomVer = ROM_Version_5,
-	.m_u32EnDISBBM = 0,
-	.m_u32EnBootStreamVerify = 0,
-	.m_u32UseNfcGeo = 0,
-	.m_u32UseMultiBootArea = 0,
-	.m_u32UseSinglePageStride = 0,
-	.m_u32DBBT_FingerPrint = DBBT_FINGERPRINT2,
-	.m_u32MaxEccStrength = 62,
-	.rom_mtd_init = v4_rom_mtd_init,
-	.rom_mtd_commit_structures = v5_rom_mtd_commit_structures,
-};
-
 static platform_config mx8mq_boot_config = {
 	.m_u32RomVer = ROM_Version_6,
 	.m_u32EnDISBBM = 0,
@@ -187,6 +174,19 @@ static platform_config mx8mq_boot_config = {
 	.m_u32MaxEccStrength = 62,
 	.rom_mtd_init = v4_rom_mtd_init,
 	.rom_mtd_commit_structures = v7_rom_mtd_commit_structures,
+};
+
+static platform_config mx8q_boot_config = {
+	.m_u32RomVer = ROM_Version_7,
+	.m_u32EnDISBBM = 0,
+	.m_u32EnBootStreamVerify = 0,
+	.m_u32UseNfcGeo = 0,
+	.m_u32UseMultiBootArea = 0,
+	.m_u32UseSinglePageStride = 0,
+	.m_u32DBBT_FingerPrint = DBBT_FINGERPRINT2,
+	.m_u32MaxEccStrength = 62,
+	.rom_mtd_init = v4_rom_mtd_init,
+	.rom_mtd_commit_structures = v5_rom_mtd_commit_structures,
 };
 
 int discover_boot_rom_version(void)


### PR DESCRIPTION
i.MX8Q changed the secondary boot stream offset since B0 as the
following table, users can specify the offset and change the fuse value
accordingly.

e.g, the --secondary_boot_stream_off_in_MB by default set to 64MB, the
fuse should be set as fuse.w 720 0x06000000

 +-----------------------+---------------+-----------------------+
 |         FUSE          |       N       |      OFFSET(MB)                         |
 +-----------------------+---------------+-----------------------+
 |          0            |       2       |          4            |
 +-----------------------+---------------+-----------------------+
 |          1            |       1       |          2            |
 +-----------------------+---------------+-----------------------+
 |          2            |       x       |          x            |
 +-----------------------+---------------+-----------------------+
 |          3            |       3       |          8            |
 +-----------------------+---------------+-----------------------+
 |          4            |       4       |          16           |
 +-----------------------+---------------+-----------------------+
 |          5            |       5       |          32           |
 +-----------------------+---------------+-----------------------+
 |          6            |       6       |          64           |
 +-----------------------+---------------+-----------------------+
 |          7            |       7       |          128          |
 +-----------------------+---------------+-----------------------+
 |          8            |       8       |          256          |
 +-----------------------+---------------+-----------------------+
 |          9            |       9       |          512          |
 +-----------------------+---------------+-----------------------+
 |          10           |       10      |          1024         |
 +-----------------------+---------------+-----------------------+
 |          others       |               disabled                |
 +-----------------------+---------------------------------------+

Signed-off-by: Han Xu <han.xu@nxp.com>