### PR TITLE
support the i.MX8MN platform and set the boot search count from fuse

### DIFF
--- a/src/plat_boot_config.c
+++ b/src/plat_boot_config.c
@@ -203,6 +203,7 @@ int discover_boot_rom_version(void)
 	static char  *plat_imx8q = "i.MX8Q"; /* i.MX8QM or i.MX8QXP */
 	static char  *plat_imx8mq = "i.MX8MQ"; /* i.MX8MQ(mscale) */
 	static char  *plat_imx8mm = "i.MX8MM";
+	static char  *plat_imx8mn = "i.MX8MN";
 	char *rev;
 	int system_rev, hw_system_rev = 0;
 
@@ -225,6 +226,10 @@ int discover_boot_rom_version(void)
 
 			plat_config_data = &mx8mq_boot_config;
 			plat_config_data->m_u32Arm_type = MX8MQ;
+			return 0;
+		} else if (!strncmp(line_buffer, plat_imx8mn, strlen(plat_imx8mn))) {
+			plat_config_data = &mx8q_boot_config;
+			plat_config_data->m_u32Arm_type = MX8MN;
 			return 0;
 		}
 

--- a/src/plat_boot_config.h
+++ b/src/plat_boot_config.h
@@ -48,6 +48,7 @@
 
 #define MX8Q	0x8
 #define MX8MQ	0x81
+#define MX8MN	0x82
 
 typedef struct _platform_config_t {
 	uint32_t m_u32RomVer;


### PR DESCRIPTION
Add the new i.MX8MN platform support and change the read from fuse for
both i.MX8Q and i.MX8MN.

Signed-off-by: Han Xu <han.xu@nxp.com>