### PR TITLE
Fix incorrect failing on mtd_erase

### DIFF
--- a/src/mtd.c
+++ b/src/mtd.c
@@ -178,6 +178,13 @@ int mtd_erase(struct mtd_data *md, int chip, loff_t ofs, size_t size)
 
 	nerase = 0;
 	while (size > 0) {
+		if (ofs >= md->part[chip].info.size) {
+			fprintf(stderr, "mtd: erase stepping bounds\n"
+				"\tofs >= chip_size\n"
+				"\t%#llx >= %#x\n",
+				(unsigned long long)ofs, md->part[chip].info.size);
+			return -1;
+		}
 		if (ofs + size > md->part[chip].info.size)
 			chunk = md->part[chip].info.size - ofs;
 		else
@@ -201,13 +208,6 @@ int mtd_erase(struct mtd_data *md, int chip, loff_t ofs, size_t size)
 		nerase += chunk;
 		ofs += chunk;
 		size -= chunk;
-		if (ofs >= md->part[chip].info.size) {
-			fprintf(stderr, "mtd: erase stepping bounds\n"
-				"\tofs >= chip_size\n"
-				"\t%#llx >= %#x\n",
-				(unsigned long long)ofs, md->part[chip].info.size);
-			return -1;
-		}
 	}
 
 	return nerase;


### PR DESCRIPTION
In the event where the mtd_erase function also needs to erase the last
block of an mtd device, the erasing goes well but the ofs check causes
the function to fail even though the erasing of the block went well.

This commit ensures that checking whether ofs does not overrun the mtd
size happens as early as possible, thus allowing the mtd_erase function
to return properly when everything went right in erasing the last block
of an mtd device.