### PR TITLE
Feature/imx6qdl leave ecc to gpmi nand

### DIFF
--- a/src/BootControlBlocks.h
+++ b/src/BootControlBlocks.h
@@ -44,6 +44,13 @@
 #define TYPICAL_NAND_READ_SIZE              2048
 
 #define BCB_MAGIC_OFFSET	12
+#define FCB_OFFSET	2 // I do not know the reason for the two bytes.
+
+#define BCB_READ_VIA_FILE_API	(1 << 0)
+#define BCB_READ_NCB			(1 << 1)
+#define BCB_READ_LDLB			(1 << 2)
+#define BCB_READ_DBBT			(1 << 3)
+#define BCB_READ_FCB			(1 << 4)
 
 #define MAXSEQLEN 183
 

--- a/src/BootControlBlocks.h
+++ b/src/BootControlBlocks.h
@@ -349,6 +349,10 @@ typedef struct {
 		struct fcb_block FCB_Block;
 		union {
 			struct {
+				uint32_t	m_u32res;
+				uint32_t	m_u32DBBTNumOfPages;
+			};
+			struct {
 				uint32_t	m_u32NumberBB;		//!< # Bad Blocks stored in this table for NAND0.
 				uint32_t	m_u32Number2KPagesBB;	//!< Bad Blocks for NAND0 consume this # of 2K pages.
 			} v2;

--- a/src/BootControlBlocks.h
+++ b/src/BootControlBlocks.h
@@ -50,7 +50,8 @@
 #define BCB_READ_NCB			(1 << 1)
 #define BCB_READ_LDLB			(1 << 2)
 #define BCB_READ_DBBT			(1 << 3)
-#define BCB_READ_FCB			(1 << 4)
+#define BCB_READ_DBBT_FROM_FCB	(1 << 4)
+#define BCB_READ_FCB			(1 << 5)
 
 #define MAXSEQLEN 183
 

--- a/src/main.c
+++ b/src/main.c
@@ -425,26 +425,28 @@ static int perform_bootstream_update(struct mtd_data *md, FILE *infp, int image_
 		if ((image_mask & (1 << i)) == 0)
 			continue;
 
-		/* first verify it fits */
-		if (i == 0) {
-			start = md->curr_ldlb->LDLB_Block2.m_u32Firmware_startingSector  * 2048;
-			end = md->curr_ldlb->LDLB_Block2.m_u32Firmware_startingSector2 * 2048;
-		} else {
-			start = md->curr_ldlb->LDLB_Block2.m_u32Firmware_startingSector2 * 2048;
-			end = mtd_size(md);
-		}
-		avail = end - start;
+		if (plat_config_data->m_u32BCBBlocksFlags & BCB_READ_LDLB) {
+			/* first verify it fits */
+			if (i == 0) {
+				start = md->curr_ldlb->LDLB_Block2.m_u32Firmware_startingSector  * 2048;
+				end = md->curr_ldlb->LDLB_Block2.m_u32Firmware_startingSector2 * 2048;
+			} else {
+				start = md->curr_ldlb->LDLB_Block2.m_u32Firmware_startingSector2 * 2048;
+				end = mtd_size(md);
+			}
+			avail = end - start;
 
-		if (avail <= size) {
-			fprintf(stderr, "image #d does not fit (avail = %u, size = %u)\n", avail, size);
-			exit(5);
-		}
+			if (avail <= size) {
+				fprintf(stderr, "image #d does not fit (avail = %u, size = %u)\n", avail, size);
+				exit(5);
+			}
 
-		/* now update size */
-		if (i == 0)
-			md->curr_ldlb->LDLB_Block2.m_uSectorsInFirmware = (size + 2047) / 2048;
-		else
-			md->curr_ldlb->LDLB_Block2.m_uSectorsInFirmware2 = (size + 2047) / 2048;
+			/* now update size */
+			if (i == 0)
+				md->curr_ldlb->LDLB_Block2.m_uSectorsInFirmware = (size + 2047) / 2048;
+			else
+				md->curr_ldlb->LDLB_Block2.m_uSectorsInFirmware2 = (size + 2047) / 2048;
+		}
 		update |= UPDATE_BS(i);
 	}
 

--- a/src/main.c
+++ b/src/main.c
@@ -179,7 +179,7 @@ int extract_main(int argc, char **argv)
 	char buf[512];
 	struct mtd_config cfg;
 	uint8_t key[16];
-	long end_of_file, pos;
+	long end_of_file = 0, pos;
 	char ascii[20 * 2 + 1];
 	FILE *tfp;
 	int readn, chunk, curr;

--- a/src/main.c
+++ b/src/main.c
@@ -82,6 +82,7 @@ void usage(void)
 	"    -x .................................... Add 1k-padding in the head\n"
 	"    -n .................................... Dry run (don't commit to flash)\n"
 	"    -w .................................... Commit to flash\n"
+	"    -s .................................... Switch Firmware_startingPages 1<->2\n"
 	"\n"
 	"  update [-v] [KEY] [KOBS] [-0|1] <file> .. Update a single bootstream\n"
 	"    -v .................................... Verbose mode\n"
@@ -675,6 +676,9 @@ int init_main(int argc, char **argv)
 				break;
 			case 'v':
 				flags |= F_VERBOSE;
+				break;
+			case 's':
+				flags |= F_FW_SLOT_SWITCH;
 				break;
 		}
 	}

--- a/src/mtd.c
+++ b/src/mtd.c
@@ -933,7 +933,7 @@ struct mtd_data *mtd_open(const struct mtd_config *cfg, int flags)
 								md->cfg.search_exponent = 1;
 						}
 					}
-				vp(md, "mtd: search_exponent was set by fuse as %d\n"
+				vp(md, "mtd: search_exponent was set as %d\n"
 						, md->cfg.search_exponent);
 				}
 			}

--- a/src/mtd.c
+++ b/src/mtd.c
@@ -1629,7 +1629,7 @@ static int mtd_load_discoverable_bad_block_table(struct mtd_data *md, int stride
 	void *buf;
 	int chip;
 
-	if (plat_config_data->m_u32BCBBlocksFlags & (BCB_READ_FCB || BCB_READ_VIA_FILE_API)) {
+	if (plat_config_data->m_u32BCBBlocksFlags & (BCB_READ_FCB || BCB_READ_VIA_FILE_API || BCB_READ_DBBT_FROM_FCB)) {
 		loff_t dbbt_offset = md->fcb.FCB_Block.m_u32DBBTSearchAreaStartAddress * md->fcb.FCB_Block.m_u32PageDataSize;
 		const size_t dbbt_size = sizeof(md->dbbt50.DBBT_Block.v3) + offsetof(BCB_ROM_BootBlockStruct_t, DBBT_Block);
 		for (i = 0; i < 3; i++) {

--- a/src/mtd.c
+++ b/src/mtd.c
@@ -879,9 +879,6 @@ struct mtd_data *mtd_open(const struct mtd_config *cfg, int flags)
 	    || plat_config_data->m_u32Arm_type == MX6Q
 	    || plat_config_data->m_u32Arm_type == MX6DL) {
 
-		md->cfg.search_exponent = 1;
-		vp(md, "mtd: search_exponent set to 1 by default\n");
-
 		/* open the nvmem file */
 		if (plat_config_data->m_u32Arm_type == MX8Q) {
 			fp = fopen("/sys/bus/nvmem/devices/imx-ocotp0/nvmem", "rb");
@@ -891,6 +888,8 @@ struct mtd_data *mtd_open(const struct mtd_config *cfg, int flags)
 		}
 		if (plat_config_data->m_u32Arm_type == MX8MN ||
 		    plat_config_data->m_u32Arm_type == MX8MP) {
+			md->cfg.search_exponent = 1;
+			vp(md, "mtd: search_exponent set to 1 by default\n");
 			fp = fopen("/sys/bus/nvmem/devices/imx-ocotp0/nvmem", "rb");
 			fuse_off = MX8MN_FUSE_NAND_SEARCH_CNT_OFFS;
 			fuse_bit = MX8MN_FUSE_NAND_SEARCH_CNT_BIT_OFFS;
@@ -915,7 +914,6 @@ struct mtd_data *mtd_open(const struct mtd_config *cfg, int flags)
 					// see linux kernel's imx-ocotp.c:imx_ocotp_read
 					if (word == 0xBADABADA) {
 						vp(md, "mtd: read back a \"read locked\" register. Got invalid value: 0x%x\n", word);
-						md->cfg.search_exponent = 1;
 					} else {
 						word &= 0x000f;
 						vp(md, "mtd: read back from fuse: %x\n", word);

--- a/src/mtd.c
+++ b/src/mtd.c
@@ -1655,8 +1655,7 @@ static int mtd_load_discoverable_bad_block_table(struct mtd_data *md, int stride
 	if (plat_config_data->m_u32BCBBlocksFlags & (BCB_READ_FCB || BCB_READ_VIA_FILE_API || BCB_READ_DBBT_FROM_FCB)) {
 		loff_t dbbt_offset = md->fcb.FCB_Block.m_u32DBBTSearchAreaStartAddress * md->fcb.FCB_Block.m_u32PageDataSize;
 		const size_t dbbt_size = sizeof(md->dbbt50.DBBT_Block.v3) + offsetof(BCB_ROM_BootBlockStruct_t, DBBT_Block);
-		/* The search limit _should_ be read from an OTP (fuse) */
-		for (i = 0; i < 3; i++) {
+		for (i = 0; i < (1 << md->cfg.search_exponent); i++) {
 			r = mtd_read(md, 0, &md->dbbt50, dbbt_size, dbbt_offset);
 			if (r != dbbt_size)
 				continue;

--- a/src/mtd.c
+++ b/src/mtd.c
@@ -3516,7 +3516,7 @@ int v0_rom_mtd_commit_structures(struct mtd_data *md, FILE *fp, int flags)
 	return 0;
 }
 
-static void dbbt_checksum(struct mtd_data *md, BCB_ROM_BootBlockStruct_t *dbbt)
+uint32_t checksum(const uint8_t *ptr, size_t size)
 {
 	uint32_t  accumulator = 0;
 	uint8_t   *p, *q;
@@ -3525,15 +3525,20 @@ static void dbbt_checksum(struct mtd_data *md, BCB_ROM_BootBlockStruct_t *dbbt)
 	 * The checksum should do 508 bytes. But if the rest of the buffer is
 	 * zero. We can only add the non-zero data for the checksum.
 	 */
-	p = ((uint8_t *) dbbt) + 4;
-	q = (uint8_t *) (dbbt + 1);
-	vp(md, "DBBT checksum length : %d\n", q - p);
+	p = ((uint8_t *) boot_block_structure) + 4;
+	q = (uint8_t *) (boot_block_structure + 1);
+	vp(md, "checksum length : %d\n", q - p);
 
 	for (; p < q; p++)
 		accumulator += *p;
 	accumulator ^= 0xffffffff;
 
-	dbbt->m_u32Checksum = accumulator;
+	return accumulator;
+}
+
+static void dbbt_checksum(struct mtd_data *md, BCB_ROM_BootBlockStruct_t *boot_block_structure)
+{
+	boot_block_structure->m_u32Checksum = checksum(md, boot_block_structure);
 }
 
 static void write_dbbt(struct mtd_data *md, int dbbt_num)

--- a/src/mtd.c
+++ b/src/mtd.c
@@ -3354,110 +3354,117 @@ int write_extra_boot_stream(struct mtd_data *md, FILE *fp)
 	return 0;
 }
 
-
-int write_boot_stream(struct mtd_data *md, FILE *fp)
+int _write_boot_stream(struct mtd_data *md, FILE *fp, int slot)
 {
 	int startpage, start, size;
 	loff_t ofs, end;
-	int i, r, chunk;
+	int i = slot, r, chunk;
 	int chip = 0;
 	struct fcb_block *fcb = &md->fcb.FCB_Block;
 
-	vp(md, "---------- Start to write the [ %s ]----\n", (char*)md->private);
-	for (i = 0; i < 2; i++) {
-		if (fp == NULL)
-			continue;
-
-		if (i == 0) {
-			startpage = fcb->m_u32Firmware1_startingPage;
-			size      = fcb->m_u32PagesInFirmware1;
-			if (fcb->m_u32Firmware2_startingPage > fcb->m_u32Firmware1_startingPage) {
-				end   = fcb->m_u32Firmware2_startingPage;
-			} else {
-				end   = mtd_size(md) / mtd_writesize(md);
-			}
+	if (i == 0) {
+		startpage = fcb->m_u32Firmware1_startingPage;
+		size      = fcb->m_u32PagesInFirmware1;
+		if (fcb->m_u32Firmware2_startingPage > fcb->m_u32Firmware1_startingPage) {
+			end   = fcb->m_u32Firmware2_startingPage;
 		} else {
-			startpage = fcb->m_u32Firmware2_startingPage;
-			size      = fcb->m_u32PagesInFirmware2;
-			if (fcb->m_u32Firmware1_startingPage > fcb->m_u32Firmware2_startingPage) {
-				end   = fcb->m_u32Firmware1_startingPage;
-			} else {
-				end   = mtd_size(md) / mtd_writesize(md);
-			}
+			end   = mtd_size(md) / mtd_writesize(md);
+		}
+	} else {
+		startpage = fcb->m_u32Firmware2_startingPage;
+		size      = fcb->m_u32PagesInFirmware2;
+		if (fcb->m_u32Firmware1_startingPage > fcb->m_u32Firmware2_startingPage) {
+			end   = fcb->m_u32Firmware1_startingPage;
+		} else {
+			end   = mtd_size(md) / mtd_writesize(md);
+		}
+	}
+
+	start = startpage * mtd_writesize(md);
+	size  = size      * mtd_writesize(md);
+	end   = end       * mtd_writesize(md);
+
+	vp(md, "mtd: Writting %s: #%d @%d: 0x%08x - 0x%08x\n",
+		(char*)md->private, i, chip, start, start + size);
+
+	/* Begin to write the image. */
+	rewind(fp);
+
+	ofs = start;
+	while (ofs < end && size > 0) {
+		while (mtd_isbad(md, chip, ofs) == 1) {
+			vp(md, "mtd: Skipping bad block at 0x%llx\n", ofs);
+			ofs += mtd_erasesize(md);
 		}
 
-		start = startpage * mtd_writesize(md);
-		size  = size      * mtd_writesize(md);
-		end   = end       * mtd_writesize(md);
-
-		vp(md, "mtd: Writting %s: #%d @%d: 0x%08x - 0x%08x\n",
-			(char*)md->private, i, chip, start, start + size);
-
-		/* Begin to write the image. */
-		rewind(fp);
-
-		ofs = start;
-		while (ofs < end && size > 0) {
-			while (mtd_isbad(md, chip, ofs) == 1) {
-				vp(md, "mtd: Skipping bad block at 0x%llx\n", ofs);
-				ofs += mtd_erasesize(md);
-			}
-
-			chunk = size;
-
-			/*
-			 * Check if we've entered a new block and, if so, erase
-			 * it before beginning to write it.
-			 */
-			if ((ofs % mtd_erasesize(md)) == 0) {
-				r = mtd_erase_block(md, chip, ofs);
-				if (r < 0) {
-					fprintf(stderr, "mtd: Failed to erase block"
-						       "@0x%llx\n", ofs);
-					ofs += mtd_erasesize(md);
-					continue;
-				}
-			}
-
-			if (chunk > mtd_writesize(md))
-				chunk = mtd_writesize(md);
-
-			r = fread(md->buf, 1, chunk, fp);
-			if (r < 0) {
-				fprintf(stderr, "mtd: Failed %d (fread %d)\n", r, chunk);
-				return -1;
-			}
-			if (r < chunk) {
-				memset(md->buf + r, 0, chunk - r);
-				vp(md, "mtd: The last page is not full : %d\n", r);
-			}
-
-			/* write page */
-			r = mtd_write_page(md, chip, ofs, 1);
-			if (r != mtd_writesize(md))
-				fprintf(stderr, "mtd: Failed to write BS @0x%llx (%d)\n",
-					ofs, r);
-
-			ofs += mtd_writesize(md);
-			size -= chunk;
-		}
+		chunk = size;
 
 		/*
-		 * Write one safe guard page:
-		 *  The Image_len of uboot is bigger then the real size of
-		 *  uboot by 1K. The ROM will get all 0xff error in this case.
-		 *  So we write one more page for safe guard.
-		 */
-		memset(md->buf, 0, mtd_writesize(md));
-		r = mtd_write_page(md, chip, ofs, 1);
-		if (r != mtd_writesize(md))
-			fprintf(stderr, "Failed to write safe page\n");
-		vp(md, "mtd: We write one page for save guard. *\n");
+			* Check if we've entered a new block and, if so, erase
+			* it before beginning to write it.
+			*/
+		if ((ofs % mtd_erasesize(md)) == 0) {
+			r = mtd_erase_block(md, chip, ofs);
+			if (r < 0) {
+				fprintf(stderr, "mtd: Failed to erase block"
+							"@0x%llx\n", ofs);
+				ofs += mtd_erasesize(md);
+				continue;
+			}
+		}
 
-		if (ofs >= end) {
-			fprintf(stderr, "mtd: Failed to write BS#%d\n", i);
+		if (chunk > mtd_writesize(md))
+			chunk = mtd_writesize(md);
+
+		r = fread(md->buf, 1, chunk, fp);
+		if (r < 0) {
+			fprintf(stderr, "mtd: Failed %d (fread %d)\n", r, chunk);
 			return -1;
 		}
+		if (r < chunk) {
+			memset(md->buf + r, 0, chunk - r);
+			vp(md, "mtd: The last page is not full : %d\n", r);
+		}
+
+		/* write page */
+		r = mtd_write_page(md, chip, ofs, 1);
+		if (r != mtd_writesize(md))
+			fprintf(stderr, "mtd: Failed to write BS @0x%llx (%d)\n",
+				ofs, r);
+
+		ofs += mtd_writesize(md);
+		size -= chunk;
+	}
+
+	/*
+		* Write one safe guard page:
+		*  The Image_len of uboot is bigger then the real size of
+		*  uboot by 1K. The ROM will get all 0xff error in this case.
+		*  So we write one more page for safe guard.
+		*/
+	memset(md->buf, 0, mtd_writesize(md));
+	r = mtd_write_page(md, chip, ofs, 1);
+	if (r != mtd_writesize(md))
+		fprintf(stderr, "Failed to write safe page\n");
+	vp(md, "mtd: We write one page for save guard. *\n");
+
+	if (ofs >= end) {
+		fprintf(stderr, "mtd: Failed to write BS#%d\n", i);
+		return -1;
+	}
+
+	return 0;
+}
+
+int write_boot_stream(struct mtd_data *md, FILE *fp)
+{
+	int i, r;
+
+	vp(md, "---------- Start to write the [ %s ]----\n", (char*)md->private);
+	for (i = 0; i < 2; i++) {
+		r = _write_boot_stream(md, fp, i);
+		if(r)
+			return r;
 	}
 	return 0;
 }
@@ -3884,6 +3891,14 @@ int v4_rom_mtd_commit_structures(struct mtd_data *md, FILE *fp, int flags)
 	loff_t ofs;
 	struct mtd_config *cfg = &md->cfg;
 
+	if (md->flags & F_FW_SLOT_SWITCH) {
+		/* [0] Write the 1st boot streams. */
+		vp(md, "---------- Start to write the [ %s ]----\n", (char*)md->private);
+		r = _write_boot_stream(md, fp, 0);
+		if (r)
+			return r;
+	}
+
 	/* [1] Write the FCB search area. */
 	size = mtd_writesize(md) + mtd_oobsize(md);
 	memset(md->buf, 0, size);
@@ -3915,8 +3930,15 @@ int v4_rom_mtd_commit_structures(struct mtd_data *md, FILE *fp, int flags)
 		}
 	}
 
-	/* [3] Write the two boot streams. */
-	return write_boot_stream(md, fp);
+	if (md->flags & F_FW_SLOT_SWITCH) {
+		/* [3] Write the 2nd boot streams. */
+		vp(md, "---------- Start to write the [ %s ]----\n", (char*)md->private);
+		r = _write_boot_stream(md, fp, 1);
+		return r;
+	} else {
+		/* [3] Write the two boot streams. */
+		return write_boot_stream(md, fp);
+	}
 }
 
 int v5_rom_mtd_commit_structures(struct mtd_data *md, FILE *fp, int flags)
@@ -3924,6 +3946,14 @@ int v5_rom_mtd_commit_structures(struct mtd_data *md, FILE *fp, int flags)
 	int size, i, r, chip = 0;
 	loff_t ofs;
 	struct mtd_config *cfg = &md->cfg;
+
+	if (md->flags & F_FW_SLOT_SWITCH) {
+		/* [0] Write the 1st boot streams. */
+		vp(md, "---------- Start to write the [ %s ]----\n", (char*)md->private);
+		r = _write_boot_stream(md, fp, 0);
+		if (r)
+			return r;
+	}
 
 	/* [1] Write the FCB search area. */
 	size = mtd_writesize(md) + mtd_oobsize(md);
@@ -3961,8 +3991,15 @@ int v5_rom_mtd_commit_structures(struct mtd_data *md, FILE *fp, int flags)
 		}
 	}
 
-	/* [3] Write the two boot streams. */
-	return write_boot_stream(md, fp);
+	if (md->flags & F_FW_SLOT_SWITCH) {
+		/* [3] Write the 2nd boot streams. */
+		vp(md, "---------- Start to write the [ %s ]----\n", (char*)md->private);
+		r = _write_boot_stream(md, fp, 1);
+		return r;
+	} else {
+		/* [3] Write the two boot streams. */
+		return write_boot_stream(md, fp);
+	}
 }
 
 int v6_rom_mtd_commit_structures(struct mtd_data *md, FILE *fp, int flags)
@@ -3970,6 +4007,14 @@ int v6_rom_mtd_commit_structures(struct mtd_data *md, FILE *fp, int flags)
 	int size, i, r, chip = 0;
 	loff_t ofs;
 	struct mtd_config *cfg = &md->cfg;
+
+	if (md->flags & F_FW_SLOT_SWITCH) {
+		/* [0] Write the 1st boot streams. */
+		vp(md, "---------- Start to write the [ %s ]----\n", (char*)md->private);
+		r = _write_boot_stream(md, fp, 0);
+		if (r)
+			return r;
+	}
 
 	/* [1] Write the FCB search area. */
 	size = mtd_writesize(md) + mtd_oobsize(md);
@@ -4003,8 +4048,15 @@ int v6_rom_mtd_commit_structures(struct mtd_data *md, FILE *fp, int flags)
 		}
 	}
 
-	/* [3] Write the two boot streams. */
-	return write_boot_stream(md, fp);
+	if (md->flags & F_FW_SLOT_SWITCH) {
+		/* [3] Write the 2nd boot streams. */
+		vp(md, "---------- Start to write the [ %s ]----\n", (char*)md->private);
+		r = _write_boot_stream(md, fp, 1);
+		return r;
+	} else {
+		/* [3] Write the two boot streams. */
+		return write_boot_stream(md, fp);
+	}
 }
 
 int v7_rom_mtd_commit_structures(struct mtd_data *md, FILE *fp, int flags)

--- a/src/mtd.c
+++ b/src/mtd.c
@@ -1655,6 +1655,9 @@ static int mtd_load_discoverable_bad_block_table(struct mtd_data *md, int stride
 	if (plat_config_data->m_u32BCBBlocksFlags & (BCB_READ_FCB || BCB_READ_VIA_FILE_API || BCB_READ_DBBT_FROM_FCB)) {
 		loff_t dbbt_offset = md->fcb.FCB_Block.m_u32DBBTSearchAreaStartAddress * md->fcb.FCB_Block.m_u32PageDataSize;
 		const size_t dbbt_size = sizeof(md->dbbt50.DBBT_Block.v3) + offsetof(BCB_ROM_BootBlockStruct_t, DBBT_Block);
+		if (plat_config_data->m_u32UseMultiBootArea) {
+			fprintf(stderr, "mtd: warning examining only first FCB.\n");
+		}
 		for (i = 0; i < (1 << md->cfg.search_exponent); i++) {
 			r = mtd_read(md, 0, &md->dbbt50, dbbt_size, dbbt_offset);
 			if (r != dbbt_size)

--- a/src/mtd.c
+++ b/src/mtd.c
@@ -329,7 +329,7 @@ int mtd_read_page(struct mtd_data *md, int chip, loff_t ofs, int ecc)
 		struct nfc_geometry *nfc_geo = &md->nfc_geometry;
 		int eccbits = nfc_geo->ecc_strength * nfc_geo->gf_len;
 		int chunksize = nfc_geo->ecc_chunkn_size_in_bytes;
-		int dst_bit_off;
+		int dst_bit_off = 0;
 		int oob_bit_off;
 		int oob_bit_left;
 		int ecc_chunk_count;
@@ -445,7 +445,7 @@ int mtd_write_page(struct mtd_data *md, int chip, loff_t ofs, int ecc)
 		struct nfc_geometry *nfc_geo = &md->nfc_geometry;
 		int eccbits = nfc_geo->ecc_strength * nfc_geo->gf_len;
 		int chunksize = nfc_geo->ecc_chunkn_size_in_bytes;
-		int src_bit_off;
+		int src_bit_off = 0;
 		int oob_bit_off;
 		int oob_bit_left;
 		int ecc_chunk_count;

--- a/src/mtd.c
+++ b/src/mtd.c
@@ -918,7 +918,7 @@ struct mtd_data *mtd_open(const struct mtd_config *cfg, int flags)
 					} else {
 						word &= 0x000f;
 						vp(md, "mtd: read back from fuse: %x\n", word);
-						switch ((word >> fuse_bit) && fuse_mask) {
+						switch ((word >> fuse_bit) & fuse_mask) {
 							case 0:
 							case 1:
 								md->cfg.search_exponent = 1;

--- a/src/mtd.h
+++ b/src/mtd.h
@@ -47,6 +47,7 @@
 #define F_VERBOSE		0x01
 #define F_MULTICHIP		0x02
 #define F_AUTO_MULTICHIP	0x04
+#define F_FW_SLOT_SWITCH	0x08
 
 #define vp(x, ...)	\
 	do {		\

--- a/src/mtd.h
+++ b/src/mtd.h
@@ -323,6 +323,8 @@ void mtd_parse_args(struct mtd_config *cfg, int argc, char **argv);
 void mtd_parse_kobs(struct mtd_config *cfg, const char *name, int verbose);
 void mtd_cfg_dump(struct mtd_config *cfg);
 
+uint32_t checksum(const uint8_t *ptr, size_t size);
+
 int ncb_get_version(void *ncb_candidate, NCB_BootBlockStruct_t **result);
 int ncb_encrypt(NCB_BootBlockStruct_t *ncb, void *target, size_t size, int version);
 int fcb_encrypt(BCB_ROM_BootBlockStruct_t *fcb, void *target, size_t size, int version);

--- a/src/plat_boot_config.c
+++ b/src/plat_boot_config.c
@@ -209,6 +209,8 @@ int discover_boot_rom_version(void)
 	char         line_buffer[100];
 	static char  *banner = "Revision";
 	static char  *banner_hw = "Hardware";
+	static char  *plat_imx6q = "i.MX6Q";
+	static char  *plat_imx6dl = "i.MX6DL";
 	static char  *plat_imx6sx = "i.MX6SX";
 	static char  *plat_imx6ul = "i.MX6UL";
 	static char  *plat_imx6ull = "i.MX6ULL";
@@ -346,6 +348,13 @@ int discover_boot_rom_version(void)
 				if (!strncmp(line_buffer, plat_imx6ul, strlen(plat_imx6ul)) ||
 					!strncmp(line_buffer, plat_imx6ull, strlen(plat_imx6ull)))
 					plat_config_data = &mx6ul_boot_config;
+
+				/* system_rev is not specific enough */
+				if (!strncmp(line_buffer, plat_imx6dl, strlen(plat_imx6dl)))
+					plat_config_data->m_u32Arm_type = MX6DL;
+				else if (!strncmp(line_buffer, plat_imx6q, strlen(plat_imx6q)))
+					plat_config_data->m_u32Arm_type = MX6Q;
+
 				break;
 
 			case MX7:
@@ -359,7 +368,8 @@ int discover_boot_rom_version(void)
 
 			fclose(cpuinfo);
 			if (plat_config_data) {
-				plat_config_data->m_u32Arm_type = system_rev;
+				if (!plat_config_data->m_u32Arm_type)
+					plat_config_data->m_u32Arm_type = system_rev;
 				return 0;
 			}
 			return -1;

--- a/src/plat_boot_config.c
+++ b/src/plat_boot_config.c
@@ -112,7 +112,7 @@ static platform_config mx6q_boot_config = {
 	.m_u32UseSinglePageStride = 0,
 	.m_u32DBBT_FingerPrint = DBBT_FINGERPRINT2,
 	.m_u32MaxEccStrength = 40,
-	.m_u32BCBBlocksFlags = (BCB_READ_FCB | BCB_READ_VIA_FILE_API),
+	.m_u32BCBBlocksFlags = (BCB_READ_FCB | BCB_READ_DBBT | BCB_READ_DBBT_FROM_FCB | BCB_READ_VIA_FILE_API),
 	.rom_mtd_init = v4_rom_mtd_init,
 	.rom_mtd_commit_structures = v4_rom_mtd_commit_structures,
 };

--- a/src/plat_boot_config.c
+++ b/src/plat_boot_config.c
@@ -38,6 +38,7 @@ static platform_config mx23_boot_config = {
 	.m_u32UseSinglePageStride = 0,
 	.m_u32DBBT_FingerPrint = DBBT_FINGERPRINT2,
 	.m_u32MaxEccStrength = 20,
+	.m_u32BCBBlocksFlags = (BCB_READ_NCB | BCB_READ_LDLB),
 	.rom_mtd_init = v0_rom_mtd_init,
 	.rom_mtd_commit_structures = v0_rom_mtd_commit_structures,
 };
@@ -52,6 +53,7 @@ static platform_config mx28_boot_config = {
 	.m_u32UseSinglePageStride = 1,
 	.m_u32DBBT_FingerPrint = DBBT_FINGERPRINT2,
 	.m_u32MaxEccStrength = 20,
+	.m_u32BCBBlocksFlags = (BCB_READ_NCB | BCB_READ_LDLB),
 	.rom_mtd_init = v1_rom_mtd_init,
 	.rom_mtd_commit_structures = v1_rom_mtd_commit_structures,
 };
@@ -66,6 +68,7 @@ static platform_config mx53to1_boot_config = {
 	.m_u32UseSinglePageStride = 0,
 	.m_u32DBBT_FingerPrint = DBBT_FINGERPRINT2_V2,
 	.m_u32MaxEccStrength = 40,
+	.m_u32BCBBlocksFlags = (BCB_READ_NCB | BCB_READ_LDLB),
 	.rom_mtd_init = v2_rom_mtd_init,
 	.rom_mtd_commit_structures = v2_rom_mtd_commit_structures,
 };
@@ -80,6 +83,7 @@ static platform_config mx53to2_boot_config = {
 	.m_u32UseSinglePageStride = 0,
 	.m_u32DBBT_FingerPrint = DBBT_FINGERPRINT2_V2,
 	.m_u32MaxEccStrength = 40,
+	.m_u32BCBBlocksFlags = (BCB_READ_NCB | BCB_READ_LDLB),
 	.rom_mtd_init = v2_rom_mtd_init,
 	.rom_mtd_commit_structures = v2_rom_mtd_commit_structures,
 };
@@ -94,6 +98,7 @@ static platform_config mx50_boot_config = {
 	.m_u32UseSinglePageStride = 0,
 	.m_u32DBBT_FingerPrint = DBBT_FINGERPRINT2,
 	.m_u32MaxEccStrength = 40,
+	.m_u32BCBBlocksFlags = (BCB_READ_NCB | BCB_READ_LDLB),
 	.rom_mtd_init = v4_rom_mtd_init,
 	.rom_mtd_commit_structures = v4_rom_mtd_commit_structures,
 };
@@ -107,6 +112,7 @@ static platform_config mx6q_boot_config = {
 	.m_u32UseSinglePageStride = 0,
 	.m_u32DBBT_FingerPrint = DBBT_FINGERPRINT2,
 	.m_u32MaxEccStrength = 40,
+	.m_u32BCBBlocksFlags = (BCB_READ_FCB | BCB_READ_VIA_FILE_API),
 	.rom_mtd_init = v4_rom_mtd_init,
 	.rom_mtd_commit_structures = v4_rom_mtd_commit_structures,
 };
@@ -120,6 +126,7 @@ static platform_config mx6sx_boot_config = {
 	.m_u32UseSinglePageStride = 0,
 	.m_u32DBBT_FingerPrint = DBBT_FINGERPRINT2,
 	.m_u32MaxEccStrength = 62,
+	.m_u32BCBBlocksFlags = (BCB_READ_NCB | BCB_READ_LDLB),
 	.rom_mtd_init = v4_rom_mtd_init,
 	.rom_mtd_commit_structures = v4_rom_mtd_commit_structures,
 };
@@ -133,6 +140,7 @@ static platform_config mx6sx_to_1_2_boot_config = {
 	.m_u32UseSinglePageStride = 0,
 	.m_u32DBBT_FingerPrint = DBBT_FINGERPRINT2,
 	.m_u32MaxEccStrength = 62,
+	.m_u32BCBBlocksFlags = (BCB_READ_NCB | BCB_READ_LDLB),
 	.rom_mtd_init = v4_rom_mtd_init,
 	.rom_mtd_commit_structures = v5_rom_mtd_commit_structures,
 };
@@ -146,6 +154,7 @@ static platform_config mx7d_boot_config = {
 	.m_u32UseSinglePageStride = 0,
 	.m_u32DBBT_FingerPrint = DBBT_FINGERPRINT2,
 	.m_u32MaxEccStrength = 62,
+	.m_u32BCBBlocksFlags = (BCB_READ_NCB | BCB_READ_LDLB),
 	.rom_mtd_init = v4_rom_mtd_init,
 	.rom_mtd_commit_structures = v5_rom_mtd_commit_structures,
 };
@@ -159,6 +168,7 @@ static platform_config mx6ul_boot_config = {
 	.m_u32UseSinglePageStride = 0,
 	.m_u32DBBT_FingerPrint = DBBT_FINGERPRINT2,
 	.m_u32MaxEccStrength = 40,
+	.m_u32BCBBlocksFlags = (BCB_READ_NCB | BCB_READ_LDLB),
 	.rom_mtd_init = v4_rom_mtd_init,
 	.rom_mtd_commit_structures = v6_rom_mtd_commit_structures,
 };
@@ -172,6 +182,7 @@ static platform_config mx8mq_boot_config = {
 	.m_u32UseSinglePageStride = 0,
 	.m_u32DBBT_FingerPrint = DBBT_FINGERPRINT2,
 	.m_u32MaxEccStrength = 62,
+	.m_u32BCBBlocksFlags = (BCB_READ_NCB | BCB_READ_LDLB),
 	.rom_mtd_init = v4_rom_mtd_init,
 	.rom_mtd_commit_structures = v7_rom_mtd_commit_structures,
 };
@@ -185,6 +196,7 @@ static platform_config mx8q_boot_config = {
 	.m_u32UseSinglePageStride = 0,
 	.m_u32DBBT_FingerPrint = DBBT_FINGERPRINT2,
 	.m_u32MaxEccStrength = 62,
+	.m_u32BCBBlocksFlags = (BCB_READ_NCB | BCB_READ_LDLB),
 	.rom_mtd_init = v4_rom_mtd_init,
 	.rom_mtd_commit_structures = v5_rom_mtd_commit_structures,
 };

--- a/src/plat_boot_config.h
+++ b/src/plat_boot_config.h
@@ -62,6 +62,7 @@ typedef struct _platform_config_t {
 	uint32_t m_u32Arm_type;
 	uint32_t m_u32DBBT_FingerPrint;
 	uint32_t m_u32MaxEccStrength;
+	uint32_t m_u32BCBBlocksFlags;
 	int (* rom_mtd_init)(struct mtd_data *md, FILE *fp);
 	int (* rom_mtd_commit_structures)(struct mtd_data *md, FILE *fp, int flags);
 } platform_config;


### PR DESCRIPTION
These changes add/fix support for:
- Hardware (BCH) ECC: I.e. i.MX6QDL's GPMI NAND interface
- BCB search area fuse configuration

Furthermore does this changeset a cover boot switch mechanism, courtesy of [jan Remmet](https://git.phytec.de/meta-phytec/tree/recipes-bsp/imx-kobs/imx-kobs/0001-mtd-write-boot-streams-separately.patch?h=zeus&id=72ef16bdeef886e9939ef25b66ad68bc50810a78) and  [Bernd Westermann](https://git.phytec.de/meta-phytec/tree/recipes-bsp/imx-kobs/imx-kobs/0001-Slot-switch.patch?h=zeus&id=72ef16bdeef886e9939ef25b66ad68bc50810a78)
